### PR TITLE
libMSR plugin

### DIFF
--- a/config/pwrapi_msr.m4
+++ b/config/pwrapi_msr.m4
@@ -31,7 +31,7 @@ AC_DEFUN([PWRAPI_CHECK_MSR], [
 	AC_LANG_SAVE
 	AC_LANG_CPLUSPLUS
 
-	AC_CHECK_HEADERS([msr.h], [], [pwrapi_check_msr_happy="no"])
+
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([], [
 			int a;
 		])], [pwrapi_check_msr_lib_happy="yes"],

--- a/config/pwrapi_msr.m4
+++ b/config/pwrapi_msr.m4
@@ -1,0 +1,58 @@
+
+AC_DEFUN([PWRAPI_CHECK_MSR], [
+	AC_ARG_WITH([msr], [AS_HELP_STRING([--with-msr@<:@=DIR@:>@], [Use the msr binding in directory specified (DIR).])])
+
+	pwrapi_check_msr_happy="yes"
+
+	CPPFLAGS_saved="$CPPFLAGS"
+  	LDFLAGS_saved="$LDFLAGS"
+	LIBS_saved="$LIBS"
+	MSR_LIBS=""
+
+	AS_IF([test -z "$with_msr"],
+		[MSR_CPPFLAGS=
+                 MSR_LDFLAGS=
+                 MSR_LIBS="-lmsr -lpthread"
+                 LIBS="$LIBS $MSR_LIBS"],
+		[	AS_IF([test "x$with_msr" = "xyes"],
+				[MSR_CPPFLAGS=
+           		 MSR_LDFLAGS=
+           		 MSR_LIBS="-lmsr -lpthread"
+           		 LIBS="$LIBS $MSR_LIBS"],
+				[MSR_CPPFLAGS="-I$with_msr/include"
+                 CPPFLAGS="$MSR_CPPFLAGS $CPPFLAGS"
+                 MSR_LDFLAGS="-L$with_msr/lib"
+                 LDFLAGS="$MSR_LDFLAGS $LDFLAGS"
+                 MSR_LIBS="-lmsr -lpthread"
+                 LIBS="$LIBS $MSR_LIBS"]
+		)]
+	)
+
+	AC_LANG_SAVE
+	AC_LANG_CPLUSPLUS
+
+	AC_CHECK_HEADERS([msr.h], [], [pwrapi_check_msr_happy="no"])
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([], [
+			int a;
+		])], [pwrapi_check_msr_lib_happy="yes"],
+		[pwrapi_check_msr_lib_happy="no"])
+
+	AS_IF([test "x$pwrapi_check_msr_lib_happy" = "xno"],
+		[pwrapi_check_msr_happy="no"])
+
+	AC_LANG_RESTORE
+
+	CPPFLAGS="$CPPFLAGS_saved"
+	LDFLAGS="$LDFLAGS_saved"
+	LIBS="$LIBS_saved"
+
+	AC_SUBST([MSR_CPPFLAGS])
+	AC_SUBST([MSR_LDFLAGS])
+	AC_SUBST([MSR_LIBS])
+
+	AM_CONDITIONAL([HAVE_MSR], [test "x$pwrapi_check_msr_happy" = "xyes"])
+	AS_IF([test "x$pwrapi_check_msr_happy" = "xyes"],
+		[AC_DEFINE([HAVE_MSR], [1], [Set to 1 if msr is found during configuration])])
+
+	AS_IF([test "x$pwrapi_check_msr_happy" = "xyes"], [$1], [$2])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ m4_include([config/acx_mpi.m4])
 m4_include([config/pwrapi_mpi.m4])
 m4_include([config/pwrapi_hwloc.m4])
 m4_include([config/pwrapi_mic.m4])
+m4_include([config/pwrapi_msr.m4])
 
 PWRAPI_CHECK_HWLOC([pwrapi_have_hwloc="yes"], [pwrapi_have_hwloc="no"])
 PWRAPI_CHECK_SWIG([pwrapi_have_swig="yes"], [pwrapi_have_swig="no"])
@@ -51,6 +52,8 @@ PWRAPI_CHECK_MPI([pwrapi_have_mpi="yes"], [pwrapi_have_mpi="no"])
 
 PWRAPI_CHECK_MIC([pwrapi_have_mic="yes"], [pwrapi_have_mic="no"])
 
+PWRAPI_CHECK_MSR([pwrapi_have_msr="yes"], [pwrapi_have_msr="no"])
+
 PWRAPI_CHECK_DEBUG()
 
 AC_CONFIG_FILES([Makefile
@@ -59,6 +62,7 @@ AC_CONFIG_FILES([Makefile
                  tools/script/hwloc_cpu_profile
                  tools/script/hwloc_rapl_profile
                  tools/script/hwloc_multi_profile
+                 tools/script/hwloc_msr_profile
                  examples/script/xml_profile
                  src/Makefile
                  src/tinyxml2/Makefile

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -5,7 +5,8 @@ lib_LTLIBRARIES =	libpwr_rapldev.la \
 			libpwr_wudev.la \
 			libpwr_cpudev.la \
 			libpwr_powercapdev.la \
-			libdummy_dev.la
+			libdummy_dev.la \
+			libpwr_msrdev.la
 
 # Power API Plugins
 if HAVE_POWERGADGET
@@ -71,3 +72,7 @@ libdummy_dev_la_LDFLAGS = -version-info 1:0:1
 libpwr_powercapdev_la_SOURCES = pwr_dev.c pwr_powercap.c
 libpwr_powercapdev_la_CFLAGS = -I$(top_srcdir)/src/pwr
 libpwr_powercapdev_la_LDFLAGS = -version-info 1:0:1
+
+libpwr_msrdev_la_SOURCES = pwr_dev.c pwr_msrdev.c
+libpwr_msrdev_la_CFLAGS = -I$(top_srcdir)/src/pwr -I/path/to/libmsr/include -L/path/to/libmsr/lib -lmsr
+libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -5,8 +5,7 @@ lib_LTLIBRARIES =	libpwr_rapldev.la \
 			libpwr_wudev.la \
 			libpwr_cpudev.la \
 			libpwr_powercapdev.la \
-			libdummy_dev.la \
-			libpwr_msrdev.la
+			libdummy_dev.la
 
 # Power API Plugins
 if HAVE_POWERGADGET

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -41,6 +41,14 @@ libpwr_micdev_la_CFLAGS = -I$(top_srcdir)/src/pwr $(MIC_INCLUDE)
 libpwr_micdev_la_LDFLAGS = -version-info 1:0:1 $(MIC_LDFLAGS) $(MIC_LIBS)
 endif
 
+if HAVE_MSR
+lib_LTLIBRARIES += libpwr_msrdev.la
+
+libpwr_msrdev_la_SOURCES = pwr_dev.c pwr_msrdev.c
+libpwr_msrdev_la_CFLAGS = -I$(top_srcdir)/src/pwr $(MSR_CFLAGS)
+libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1
+endif
+
 libpwr_rapldev_la_SOURCES = pwr_dev.c pwr_rapldev.c
 libpwr_rapldev_la_CFLAGS = -I$(top_srcdir)/src/pwr
 libpwr_rapldev_la_LDFLAGS = -version-info 1:0:1
@@ -72,7 +80,3 @@ libdummy_dev_la_LDFLAGS = -version-info 1:0:1
 libpwr_powercapdev_la_SOURCES = pwr_dev.c pwr_powercap.c
 libpwr_powercapdev_la_CFLAGS = -I$(top_srcdir)/src/pwr
 libpwr_powercapdev_la_LDFLAGS = -version-info 1:0:1
-
-libpwr_msrdev_la_SOURCES = pwr_dev.c pwr_msrdev.c
-libpwr_msrdev_la_CFLAGS = -I$(top_srcdir)/src/pwr -I/path/to/libmsr/include -L/path/to/libmsr/lib -lmsr
-libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -46,7 +46,7 @@ lib_LTLIBRARIES += libpwr_msrdev.la
 
 libpwr_msrdev_la_SOURCES = pwr_dev.c pwr_msrdev.c
 libpwr_msrdev_la_CFLAGS = -I$(top_srcdir)/src/pwr $(MSR_CFLAGS)
-libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1
+libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1 $(MIC_LDFLAGS) $(MIC_LIBS)
 endif
 
 libpwr_rapldev_la_SOURCES = pwr_dev.c pwr_rapldev.c

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -46,7 +46,7 @@ lib_LTLIBRARIES += libpwr_msrdev.la
 
 libpwr_msrdev_la_SOURCES = pwr_dev.c pwr_msrdev.c
 libpwr_msrdev_la_CFLAGS = -I$(top_srcdir)/src/pwr $(MSR_CFLAGS)
-libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1 $(MIC_LDFLAGS) $(MIC_LIBS)
+libpwr_msrdev_la_LDFLAGS = -version-info 1:0:1 $(MSR_LDFLAGS) $(MSR_LIBS)
 endif
 
 libpwr_rapldev_la_SOURCES = pwr_dev.c pwr_rapldev.c

--- a/src/plugins/README
+++ b/src/plugins/README
@@ -25,15 +25,16 @@ Currently supported:
   libpwr_cpudev	  System level CPU adjustments
   libpwr_apmdev   AMD Average Power Management
   libpwr_pmcdev   IBM Power8 Power Management (INCOMPLETE)
+  libpwr_msrdev   LIBMSR
 
-Attributes  PIAPI  PI  RAPL  WU  XTPM  CPU  APM  PMC
-----------  -----  --  ----  --  ----  ---  ---  ---
-  power     G      G         G   G	   G    G
-  energy    G          G     G   G
+Attributes  PIAPI  PI  RAPL  WU  XTPM  CPU  APM  PMC  MSR
+----------  -----  --  ----  --  ----  ---  ---  ---  ---
+  power     G      G         G   G	   G    G         
+  energy    G          G     G   G                    G
   voltage   G      G         G
   current   G      G         G
   min_power                      G/S   G/S
-  max_power                      G/S   G/S
+  max_power                      G/S   G/S            G/S
   freq                                 G/S
   temp                                 G
   pstate                               G/S

--- a/src/plugins/pwr_msrdev.c
+++ b/src/plugins/pwr_msrdev.c
@@ -1,0 +1,290 @@
+#include <assert.h>
+#include "pwr_rapldev.h"
+#include "pwr_dev.h"
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include <math.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <msr_core.h>
+#include <msr_rapl.h>
+#include "pwr_msrdev.h"
+typedef struct {
+	int fd;
+	double energy;
+} pwr_msrdev_t;
+typedef struct {
+	pwr_msrdev_t *dev;
+} pwr_msrfd_t;
+#define PWR_MSRFD(X) ((pwr_msrfd_t *)(X))
+
+
+static plugin_devops_t devops = {
+	.open         = pwr_msrdev_open,
+	.close        = pwr_msrdev_close,
+	.read         = pwr_msrdev_read,
+	.write        = pwr_msrdev_write,
+	.readv        = pwr_msrdev_readv,
+	.writev       = pwr_msrdev_writev,
+	.time         = pwr_msrdev_time,
+	.clear        = pwr_msrdev_clear,
+#if 0
+	.stat_get     = pwr_dev_stat_get,
+	.stat_start   = pwr_dev_stat_start,
+	.stat_stop    = pwr_dev_stat_stop,
+	.stat_clear   = pwr_dev_stat_clear,
+#endif
+	.private_data = 0x0
+};
+
+
+static struct rapl_data *rdat;
+static uint64_t *rflags;
+plugin_devops_t *pwr_msrdev_init( const char *initstr )
+{
+	//printf("msrdev_init\n");
+	int i;
+
+	plugin_devops_t *dev = malloc( sizeof(plugin_devops_t) );
+
+	init_msr();
+	rapl_init(&rdat, &rflags);
+	//printf("msr inited\n");
+
+	//DBGP("num packages %d\n", priv->numPkgs );
+	//assert( priv->numPkgs > 0 );
+
+	*dev = devops;
+	//printf("set equaled to devops\n");
+	dev->private_data = malloc( sizeof(pwr_msrdev_t) );
+	//printf("malloced\n");
+	bzero( dev->private_data, sizeof(pwr_msrdev_t) );
+	//printf("init finished\n");
+	return dev;
+}
+
+int pwr_msrdev_final( plugin_devops_t *dev )
+{
+	free( dev->private_data );
+	free( dev );
+
+	return 0;
+}
+pwr_fd_t pwr_msrdev_open( plugin_devops_t *dev, const char *openstr )
+{
+	//printf("msr opened\n");
+	pwr_msrfd_t *fd = malloc( sizeof(pwr_msrfd_t) );
+	PWR_MSRFD(fd)->dev =(pwr_msrdev_t *)(dev->private_data);
+	PWR_MSRFD(fd)->dev->energy = 0.0;
+	return fd;
+}
+int pwr_msrdev_close( pwr_fd_t fd )
+{
+	PWR_MSRFD(fd)->dev = 0x0;
+	free( fd );
+
+	return 0;
+}
+
+int pwr_msrdev_read( pwr_fd_t fd, PWR_AttrName attr, void *value, unsigned int len, PWR_Time *timestamp )
+{
+	int i;
+	double energy = 0.0;
+	double time = 0.0;
+	int policy = 0;
+#ifndef USE_SYSTIME
+	struct timeval tv;
+#endif
+	energy=PWR_MSRFD(fd)->dev->energy;
+
+	if( len != sizeof(double) ) {
+		fprintf( stderr, "Error: value field size of %u incorrect, should be %ld\n", len, sizeof(double) );
+		return -1;
+	}
+	poll_rapl_data();
+	int snum = num_sockets();
+	for(int s = 0; s<snum; s++)
+	{
+		energy = rdat->pkg_delta_joules[s];
+	}
+	double total;
+	switch( attr ) {
+		case PWR_ATTR_ENERGY:
+			*((double *)value) = energy;
+			break;
+		case PWR_ATTR_POWER_LIMIT_MAX:
+			total = 0;
+			for(int s = 0; s<snum; s++)
+			{
+				struct rapl_limit rlimg;
+	        	        get_pkg_rapl_limit(s, &rlimg, NULL);
+				total+=rlimg.watts;
+			}
+			*((double *)value) = total;
+			break;
+
+		default:
+			fprintf( stderr, "Warning: unknown PWR reading attr requested\n" );
+			break;
+	}
+
+	PWR_MSRFD(fd)->dev->energy=energy;
+#ifndef USE_SYSTIME
+	gettimeofday( &tv, NULL );
+	*timestamp = tv.tv_sec*1000000000ULL + tv.tv_usec*1000;
+#else
+	*timestamp = (unsigned int)time*1000000000ULL + 
+		(time-(unsigned int)time)*1000000000ULL;
+#endif
+
+	return 0;
+}
+int pwr_msrdev_write( pwr_fd_t fd, PWR_AttrName attr, void *value, unsigned int len )
+{
+
+	struct rapl_limit rlim;
+	struct rapl_limit rlim2;
+	int snum;
+	double val = *(double *)value;
+	poll_rapl_data();
+	switch( attr )
+	{
+		case PWR_ATTR_POWER_LIMIT_MAX:
+			snum = num_sockets();
+			rlim.watts=val/snum;
+			rlim2.watts=val/snum;
+			rlim.bits=0;
+			rlim2.bits=0;
+			rlim.seconds=1;
+			rlim2.seconds=1;
+			for(int s = 0; s<snum; s++)
+			{
+						set_pkg_rapl_limit(s, &rlim, &rlim2);
+			}
+			break;
+		default:
+			fprintf(stderr,"Warning: unknown PWR writing attr requested\n");
+			break;
+	}
+	return 0;
+}
+
+int pwr_msrdev_readv( pwr_fd_t fd, unsigned int arraysize,
+		const PWR_AttrName attrs[], void *values, PWR_Time timestamp[], int status[] )
+{
+	unsigned int i;
+
+	for( i = 0; i < arraysize; i++ )
+		status[i] = pwr_msrdev_read( fd, attrs[i], (double *)values+i, sizeof(double), timestamp+i );
+
+	return 0;
+}
+
+int pwr_msrdev_writev( pwr_fd_t fd, unsigned int arraysize,
+		const PWR_AttrName attrs[], void *values, int status[] )
+{
+	unsigned int i;
+
+	for( i = 0; i < arraysize; i++ )
+		status[i] = pwr_msrdev_write( fd, attrs[i], (double *)values+i, sizeof(double) );
+
+	return 0;
+}
+
+int pwr_msrdev_time( pwr_fd_t fd, PWR_Time *timestamp )
+{
+	double value;
+
+	DBGP( "Info: PWR MSR device time\n" );
+
+	return pwr_msrdev_read( fd, PWR_ATTR_POWER, &value, sizeof(double), timestamp );
+}
+
+int pwr_msrdev_clear( pwr_fd_t fd )
+{
+	return 0;
+}
+
+static plugin_dev_t dev = {
+	.init   = pwr_msrdev_init,
+	.final  = pwr_msrdev_final,
+};
+
+plugin_dev_t* getDev() {
+	return &dev;
+}
+
+static int msrdev_numObjs( )
+{
+	DBGP("\n");
+	return 1;
+}
+static int msrdev_readObjs(  int i, PWR_ObjType* ptr )
+{
+	DBGP("\n");
+	ptr[0] = PWR_OBJ_NODE;
+	return 0;
+}
+
+static int msrdev_numAttrs( )
+{
+	DBGP("\n");
+	return 2;
+}
+
+static int msrdev_readAttrs( int i, PWR_AttrName* ptr )
+{
+	DBGP("\n");
+	ptr[0] = PWR_ATTR_ENERGY;
+	ptr[1] = PWR_ATTR_POWER_LIMIT_MAX;
+	return 0;
+}
+
+static int msrdev_getDevName(PWR_ObjType type, size_t len, char* buf )
+{
+	strncpy(buf,"pwr_msr_dev0", len );
+	DBGP("type=%d name=`%s`\n",type,buf);
+	return 0;
+}
+
+static int msrdev_getDevOpenStr(PWR_ObjType type,
+		int global_index, size_t len, char* buf )
+{
+	snprintf( buf, len, "%d %d", type, global_index);
+	DBGP("type=%d global_index=%d str=`%s`\n",type,global_index,buf);
+	return 0;
+}
+
+static int msrdev_getDevInitStr( const char* name,
+		size_t len, char* buf )
+{
+	snprintf(buf,len,"");
+	DBGP("dev=`%s` str=`%s`\n",name, buf );
+	return 0;
+}
+
+static int msrdev_getPluginName( size_t len, char* buf )
+{
+	snprintf(buf,len,"MSR");
+	return 0;
+}
+
+static plugin_meta_t meta = {
+	.numObjs = msrdev_numObjs,
+	.numAttrs = msrdev_numAttrs,
+	.readObjs = msrdev_readObjs,
+	.readAttrs = msrdev_readAttrs,
+	.getDevName = msrdev_getDevName,
+	.getDevOpenStr = msrdev_getDevOpenStr,
+	.getDevInitStr = msrdev_getDevInitStr,
+	.getPluginName = msrdev_getPluginName,
+};
+
+plugin_meta_t* getMeta() {
+	return &meta;
+}
+

--- a/src/plugins/pwr_msrdev.c
+++ b/src/plugins/pwr_msrdev.c
@@ -46,24 +46,16 @@ static struct rapl_data *rdat;
 static uint64_t *rflags;
 plugin_devops_t *pwr_msrdev_init( const char *initstr )
 {
-	//printf("msrdev_init\n");
 	int i;
 
 	plugin_devops_t *dev = malloc( sizeof(plugin_devops_t) );
 
 	init_msr();
 	rapl_init(&rdat, &rflags);
-	//printf("msr inited\n");
-
-	//DBGP("num packages %d\n", priv->numPkgs );
-	//assert( priv->numPkgs > 0 );
 
 	*dev = devops;
-	//printf("set equaled to devops\n");
 	dev->private_data = malloc( sizeof(pwr_msrdev_t) );
-	//printf("malloced\n");
 	bzero( dev->private_data, sizeof(pwr_msrdev_t) );
-	//printf("init finished\n");
 	return dev;
 }
 
@@ -76,7 +68,6 @@ int pwr_msrdev_final( plugin_devops_t *dev )
 }
 pwr_fd_t pwr_msrdev_open( plugin_devops_t *dev, const char *openstr )
 {
-	//printf("msr opened\n");
 	pwr_msrfd_t *fd = malloc( sizeof(pwr_msrfd_t) );
 	PWR_MSRFD(fd)->dev =(pwr_msrdev_t *)(dev->private_data);
 	PWR_MSRFD(fd)->dev->energy = 0.0;
@@ -109,7 +100,7 @@ int pwr_msrdev_read( pwr_fd_t fd, PWR_AttrName attr, void *value, unsigned int l
 	int snum = num_sockets();
 	for(int s = 0; s<snum; s++)
 	{
-		energy = rdat->pkg_delta_joules[s];
+		energy = rdat->pkg_delta_joules[s]; //change to += to get total energy
 	}
 	double total;
 	switch( attr ) {
@@ -137,7 +128,7 @@ int pwr_msrdev_read( pwr_fd_t fd, PWR_AttrName attr, void *value, unsigned int l
 	gettimeofday( &tv, NULL );
 	*timestamp = tv.tv_sec*1000000000ULL + tv.tv_usec*1000;
 #else
-	*timestamp = (unsigned int)time*1000000000ULL + 
+	*timestamp = (unsigned int)time*1000000000ULL +
 		(time-(unsigned int)time)*1000000000ULL;
 #endif
 
@@ -287,4 +278,3 @@ static plugin_meta_t meta = {
 plugin_meta_t* getMeta() {
 	return &meta;
 }
-

--- a/src/plugins/pwr_msrdev.h
+++ b/src/plugins/pwr_msrdev.h
@@ -1,0 +1,44 @@
+/*
+Copyright 2014-2016 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000, there is a non-exclusive license for use of this work
+ * by or on behalf of the U.S. Government. Export of this program may require
+ * a license from the United States Government.
+ *
+ * This file is part of the Power API Prototype software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+*/
+
+#ifndef PWR_MSRDEV_H 
+#define PWR_MSRDEV_H 
+
+#include "pwrdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+plugin_devops_t *pwr_msrdev_init( const char *initstr );
+int pwr_msrdev_final( plugin_devops_t *dev );
+
+pwr_fd_t pwr_msrdev_open( plugin_devops_t *dev, const char *openstr );
+int pwr_msrdev_close( pwr_fd_t fd );
+
+int pwr_msrdev_read( pwr_fd_t fd, PWR_AttrName attr,
+    void *value, unsigned int len, PWR_Time *timestamp );
+int pwr_msrdev_write( pwr_fd_t fd, PWR_AttrName attr,
+    void *value, unsigned int len );
+
+int pwr_msrdev_readv( pwr_fd_t fd, unsigned int arraysize,
+    const PWR_AttrName attrs[], void *values, PWR_Time timestamp[], int status[] );
+int pwr_msrdev_writev( pwr_fd_t fd, unsigned int arraysize,
+    const PWR_AttrName attrs[], void *values, int status[] );
+
+int pwr_msrdev_time( pwr_fd_t fd, PWR_Time *timestamp );
+int pwr_msrdev_clear( pwr_fd_t fd );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -8,7 +8,8 @@ script_DATA = script/hwloc_profile\
          script/hwloc_cpu_profile\
          script/hwloc_rapl_profile\
          script/hwloc_multi_profile\
-         script/hwloc_powercap_profile
+         script/hwloc_powercap_profile\
+         script/hwloc_msr_profile
 
 # Power API Tools
 pwrapi_SOURCES = pwrapi.c
@@ -59,6 +60,7 @@ config_DATA = 	config/shepard-platform.xml \
 		config/cpu.hwloc \
 		config/rapl.hwloc \
 		config/multi.hwloc \
-		config/dummyNode.hwloc
+		config/dummyNode.hwloc \
+    config/msr.hwloc
 
 EXTRA_DIST = $(config_DATA) $(script_DATA)

--- a/tools/config/msr.hwloc
+++ b/tools/config/msr.hwloc
@@ -1,0 +1,1 @@
+libpwr_msrdev

--- a/tools/script/hwloc_msr_profile.in
+++ b/tools/script/hwloc_msr_profile.in
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+#
+# Copyright 2014-2015-2015 Sandia Corporation. Under the terms of Contract
+# DE-AC04-94AL85000, there is a non-exclusive license for use of this work
+# by or on behalf of the U.S. Government. Export of this program may require
+# a license from the United States Government.
+#
+# This file is part of the Power API Prototype software package. For license
+# information, see the LICENSE file in the top level directory of the
+# distribution.
+#
+
+prefix=@prefix@
+
+export LD_LIBRARY_PATH="${prefix}/lib:${LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="${prefix}/lib:${DYLD_LIBRARY_PATH}"
+
+export POWERAPI_DEBUG=0
+export POWERAPI_ROOT="plat"
+export POWERAPI_CONFIG="${prefix}/config/msr.hwloc"
+
+export PATH="$PATH:${prefix}/bin"


### PR DESCRIPTION
Added a plugin to read/write power settings via LLNL’s libMSR library (https://github.com/LLNL/libmsr). This plugin allows researchers to access and set power capping without needing root privileges on systems running msrsafe (https://github.com/LLNL/msr-safe).